### PR TITLE
Report Period Adjustments

### DIFF
--- a/src/main/java/gov/usgs/aqcu/builder/DataGapListBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/DataGapListBuilderService.java
@@ -1,6 +1,7 @@
 package gov.usgs.aqcu.builder;
 
-import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,11 +10,12 @@ import org.springframework.stereotype.Service;
 import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.TimeSeriesPoint;
 
 import gov.usgs.aqcu.model.DataGap;
+import gov.usgs.aqcu.util.AqcuTimeUtils;
 
 @Service
 public class DataGapListBuilderService {	
 
-	public List<DataGap> buildGapList(List<TimeSeriesPoint> timeSeriesPoints) {
+	public List<DataGap> buildGapList(List<TimeSeriesPoint> timeSeriesPoints, boolean isDaily, ZoneOffset zoneOffset) {
 		List<DataGap> gapList = new ArrayList<>();
 
 		for(int i = 0; i < timeSeriesPoints.size(); i++) {
@@ -21,8 +23,8 @@ public class DataGapListBuilderService {
 
 			if(point.getValue().getNumeric() == null) {
 				//Gap Marker Found			
-				Instant preTime = (i > 0) ?  timeSeriesPoints.get(i-1).getTimestamp().getDateTimeOffset() : null;
-				Instant postTime = (i < (timeSeriesPoints.size() -1)) ? timeSeriesPoints.get(i+1).getTimestamp().getDateTimeOffset() : null;
+				Temporal preTime = (i > 0) ? AqcuTimeUtils.getTemporal(timeSeriesPoints.get(i-1).getTimestamp(), isDaily, zoneOffset) : null;
+				Temporal postTime = (i < (timeSeriesPoints.size() -1)) ? AqcuTimeUtils.getTemporal(timeSeriesPoints.get(i+1).getTimestamp(), isDaily, zoneOffset) : null;
 				DataGap gap = new DataGap();
 				gap.setStartTime(preTime);
 				gap.setEndTime(postTime);

--- a/src/main/java/gov/usgs/aqcu/model/DataGap.java
+++ b/src/main/java/gov/usgs/aqcu/model/DataGap.java
@@ -1,29 +1,37 @@
 package gov.usgs.aqcu.model;
 
-import java.time.Instant;
-import java.time.Duration;
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
 
+/** 
+ * DataGaps come in two flavors, Daily and Instantaneous. Instantaneous work on a Instant and work right off the raw value.
+ * Daily only contain a LocalDate component. Durations are calculated based on start of day at UTC.
+ *
+ */
 public class DataGap {
-	private Instant startTime = null;
-	private Instant endTime = null;
+	private Temporal startTime = null;
+	private Temporal endTime = null;
 	private BigDecimal durationInHours = null;
 	private DataGapExtent gapExtent = DataGapExtent.OVER_ALL;
 
 	public DataGap() {}
 
-	public DataGap(Instant startTime, Instant endTime) {
+	public DataGap(Temporal startTime, Temporal endTime) {
 		this.startTime = startTime;
 		this.endTime = endTime;
 		calculateDurationInHours();
 		calculateGapExtent();
 	}
 
-	public Instant getStartTime() {
+	public Temporal getStartTime() {
 		return startTime;
 	}
 
-	public Instant getEndTime() {
+	public Temporal getEndTime() {
 		return endTime;
 	}
 
@@ -35,13 +43,13 @@ public class DataGap {
 		return durationInHours;
 	}
 
-	public void setStartTime(Instant val) {
+	public void setStartTime(Temporal val) {
 		startTime= val;
 		calculateDurationInHours();
 		calculateGapExtent();
 	}
 
-	public void setEndTime(Instant val) {
+	public void setEndTime(Temporal val) {
 		endTime = val;
 		calculateDurationInHours();
 		calculateGapExtent();
@@ -49,7 +57,11 @@ public class DataGap {
 
 	protected void calculateDurationInHours() {
 		if(startTime != null && endTime != null) {
-			durationInHours = BigDecimal.valueOf(Duration.between(startTime, endTime).getSeconds() / 3600.0);
+			if(startTime instanceof Instant && endTime instanceof Instant) {
+				durationInHours = BigDecimal.valueOf(Duration.between(startTime, endTime).getSeconds() / 3600.0);
+			} else if(startTime instanceof LocalDate && endTime instanceof LocalDate) {
+				durationInHours = BigDecimal.valueOf(Duration.between(((LocalDate) startTime).atStartOfDay(ZoneId.of("Z")), ((LocalDate) endTime).atStartOfDay(ZoneId.of("Z"))).getSeconds() / 3600.0);
+			}
 		} else {
 			durationInHours = null;
 		}

--- a/src/main/java/gov/usgs/aqcu/model/ReportMetadata.java
+++ b/src/main/java/gov/usgs/aqcu/model/ReportMetadata.java
@@ -1,12 +1,10 @@
 package gov.usgs.aqcu.model;
 
-import java.util.Map;
-import java.util.HashMap;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.QualifierMetadata;
-
-import gov.usgs.aqcu.parameter.RequestParameters;
 
 public class ReportMetadata {
 	private String timezone;
@@ -23,20 +21,17 @@ public class ReportMetadata {
 
 	public ReportMetadata(
 		String reportTitle,
-		RequestParameters requestParameters,
 		Double utcOffset,
 		String stationName,
 		String stationId,
 		Map<String,QualifierMetadata> qualifierMetadata) {
 		setTitle(reportTitle);
-		setStartDate(requestParameters.getStartInstant());
-		setEndDate(requestParameters.getEndInstant());
 		setTimezone(utcOffset);
 		setStationName(stationName);
 		setStationId(stationId);
 		setQualifierMetadata(qualifierMetadata);
 	}
-	
+
 	public String getTimezone() {
 		return timezone;
 	}
@@ -52,7 +47,7 @@ public class ReportMetadata {
 	public String getTitle() {
 		return title;
 	}
-	
+
 	public String getStationName() {
 		return stationName;
 	}
@@ -64,7 +59,7 @@ public class ReportMetadata {
 	public Map<String, QualifierMetadata> getQualifierMetadata() {
 		return qualifierMetadata;
 	}
-	
+
 	public void setTimezone(String val) {
 		timezone = val;
 	}
@@ -84,7 +79,7 @@ public class ReportMetadata {
 	public void setTitle(String val) {
 		title = val;
 	}
-	
+
 	public void setStationName(String val) {
 		stationName = val;
 	}

--- a/src/main/java/gov/usgs/aqcu/util/AqcuTimeUtils.java
+++ b/src/main/java/gov/usgs/aqcu/util/AqcuTimeUtils.java
@@ -1,9 +1,13 @@
 package gov.usgs.aqcu.util;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
 
 import com.aquaticinformatics.aquarius.sdk.timeseries.serializers.InstantDeserializer;
 import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.PeriodOfApplicability;
+import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.StatisticalDateTimeOffset;
 
 public abstract class AqcuTimeUtils {
 	public static final Instant OPEN_ENDED_START_THRESHOLD = InstantDeserializer.MinConcreteValue;
@@ -28,5 +32,14 @@ public abstract class AqcuTimeUtils {
 
 	public static String toQueryDate(Instant time) {
 		return time.toString().substring(0,10);
+	}
+
+	public static Temporal getTemporal(StatisticalDateTimeOffset dateTimeOffset, boolean isDaily, ZoneOffset zoneOffset) {
+		if (dateTimeOffset.isRepresentsEndOfTimePeriod() && isDaily) {
+			// Daily values with isRepresentsEndOfTimePeriod() end up with an Instant of midnight on the next day, rather than "2400" on the actual day.
+			return LocalDateTime.ofInstant(dateTimeOffset.getDateTimeOffset(), zoneOffset).toLocalDate().minusDays(1);
+		} else {
+			return dateTimeOffset.getDateTimeOffset();
+		}
 	}
 }

--- a/src/main/java/gov/usgs/aqcu/util/AqcuTimeUtils.java
+++ b/src/main/java/gov/usgs/aqcu/util/AqcuTimeUtils.java
@@ -35,7 +35,7 @@ public abstract class AqcuTimeUtils {
 	}
 
 	public static Temporal getTemporal(StatisticalDateTimeOffset dateTimeOffset, boolean isDaily, ZoneOffset zoneOffset) {
-		if (dateTimeOffset.isRepresentsEndOfTimePeriod() && isDaily) {
+		if (dateTimeOffset.isRepresentsEndOfTimePeriod() != null && dateTimeOffset.isRepresentsEndOfTimePeriod() && isDaily) {
 			// Daily values with isRepresentsEndOfTimePeriod() end up with an Instant of midnight on the next day, rather than "2400" on the actual day.
 			return LocalDateTime.ofInstant(dateTimeOffset.getDateTimeOffset(), zoneOffset).toLocalDate().minusDays(1);
 		} else {

--- a/src/main/resources/templates/error.ftl
+++ b/src/main/resources/templates/error.ftl
@@ -4,15 +4,19 @@
 		<div id='created'>${timestamp?datetime}</div>
 		<div>There was an unexpected error (type=${error}, status=${status}).</div>
 		<div>
-			<ul>
-			<#list errors as err>
-				<#if err.field??>
-				<li>Field: ${err.field}; Value: ${err.rejectedValue!"[null]"}; Error: ${err.defaultMessage}</li>
-				<#else>
-				<li>Error: ${err.defaultMessage}</li>
-				</#if>
-			</#list>
-			</ul>
+			<#if errors??>
+				<ul>
+				<#list errors as err>
+					<#if err.field??>
+					<li>Field: ${err.field}; Value: ${err.rejectedValue!"[null]"}; Error: ${err.defaultMessage}</li>
+					<#else>
+					<li>Error: ${err.defaultMessage}</li>
+					</#if>
+				</#list>
+				</ul>
+			<#else>
+				${message}
+			</#if>
 		</div>
 	</body>
 </html>

--- a/src/test/java/gov/usgs/aqcu/parameter/RequestParametersTest.java
+++ b/src/test/java/gov/usgs/aqcu/parameter/RequestParametersTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -12,16 +13,20 @@ import org.junit.Test;
 
 public class RequestParametersTest {
 
-	RequestParameters params;
-	Instant last3MonthsBegin = Instant.parse(LocalDate.now().minusMonths(3).format(DateTimeFormatter.ofPattern("yyyy-MM")) + "-01T00:00:00.000000000Z");
-	Instant last3MonthsEnd = Instant.parse(LocalDate.now().toString() + "T23:59:59.999999999Z");
-	Instant waterYear2018Begin = Instant.parse("2017-10-01T00:00:00.000000000Z");
-	Instant waterYear2018End = Instant.parse("2018-09-30T23:59:59.999999999Z");
-	public static final Instant REPORT_END_INSTANT = Instant.parse("2018-03-16T23:59:59.999999999Z");
-	public static final Instant REPORT_START_INSTANT = Instant.parse("2018-03-16T00:00:00.000000000Z");
-	public static final LocalDate REPORT_END_DATE = LocalDate.of(2018, 03, 16);
-	public static final LocalDate REPORT_START_DATE = LocalDate.of(2018, 03, 16);
-	String primaryIdentifier = "test-identifier";
+	private RequestParameters params;
+	private LocalDate last3MonthsBeginDate = LocalDate.parse(LocalDate.now().minusMonths(3).format(DateTimeFormatter.ofPattern("yyyy-MM")) + "-01");
+	private LocalDate last3MonthsEndDate = LocalDate.now();
+	private LocalDate waterYear2018BeginDate = LocalDate.parse("2017-10-01");
+	private LocalDate waterYear2018EndDate = LocalDate.parse("2018-09-30");
+	private Instant last3MonthsBeginUtc = last3MonthsBeginDate.atStartOfDay().toInstant(ZoneOffset.UTC);
+	private Instant last3MonthsEndUtc = Instant.parse(last3MonthsEndDate.toString() + "T23:59:59.999999999Z");
+	private Instant waterYear2018BeginUtc = Instant.parse("2017-10-01T00:00:00.000000000Z");
+	private Instant waterYear2018EndUtc = Instant.parse("2018-09-30T23:59:59.999999999Z");
+	private Instant reportEndInstantUtc = Instant.parse("2018-03-16T23:59:59.999999999Z");
+	private Instant reportStartInstantUtc = Instant.parse("2018-03-16T00:00:00.000000000Z");
+	private LocalDate reportEndDate = LocalDate.of(2018, 03, 16);
+	private LocalDate reportStartDate = LocalDate.of(2018, 03, 16);
+	private String primaryIdentifier = "test-identifier";
 
 	@Before
 	public void setup() {
@@ -29,73 +34,70 @@ public class RequestParametersTest {
 	}
 
 	@Test
-	public void dateToReportEndTimeTest() {
-		assertEquals(REPORT_END_INSTANT, params.dateToReportEndTime(REPORT_END_DATE));
-	}
-
-	@Test
-	public void dateToReportStartTimeTest() {
-		assertEquals(REPORT_START_INSTANT, params.dateToReportStartTime(REPORT_START_DATE));
+	public void datesToReportPeriodTest() {
+		Pair<LocalDate,LocalDate> reportPeriod = params.datesToReportPeriod(reportStartDate, reportEndDate);
+		assertEquals(reportStartDate, reportPeriod.getLeft());
+		assertEquals(reportEndDate, reportPeriod.getRight());
 	}
 
 	@Test
 	public void lastMonthsToReportPeriodTest() {
-		Pair<Instant,Instant> reportPeriod = params.lastMonthsToReportPeriod(3);
-		assertEquals(last3MonthsBegin, reportPeriod.getLeft());
-		assertEquals(last3MonthsEnd, reportPeriod.getRight());
+		Pair<LocalDate,LocalDate> reportPeriod = params.lastMonthsToReportPeriod(3);
+		assertEquals(last3MonthsBeginDate, reportPeriod.getLeft());
+		assertEquals(last3MonthsEndDate, reportPeriod.getRight());
 	}
 
 	@Test
 	public void waterYearToReportPeriodTest() {
-		Pair<Instant,Instant> reportPeriod = params.waterYearToReportPeriod(2018);
-		assertEquals(waterYear2018Begin, reportPeriod.getLeft());
-		assertEquals(waterYear2018End, reportPeriod.getRight());
+		Pair<LocalDate,LocalDate> reportPeriod = params.waterYearToReportPeriod(2018);
+		assertEquals(waterYear2018BeginDate, reportPeriod.getLeft());
+		assertEquals(waterYear2018EndDate, reportPeriod.getRight());
 	}
 
 	@Test
 	public void determineReportPeriod_lastmonthsTest() {
 		params.setLastMonths(3);
 		params.determineReportPeriod();
-		assertEquals(last3MonthsBegin, params.getStartInstant());
-		assertEquals(last3MonthsEnd, params.getEndInstant());
+		assertEquals(last3MonthsBeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(last3MonthsEndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void determineReportPeriod_waterYearTest() {
 		params.setWaterYear(2018);
 		params.determineReportPeriod();
-		assertEquals(waterYear2018Begin, params.getStartInstant());
-		assertEquals(waterYear2018End, params.getEndInstant());
+		assertEquals(waterYear2018BeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(waterYear2018EndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void determineReportPeriod_fromDatesTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.determineReportPeriod();
-		assertEquals(REPORT_START_INSTANT, params.getStartInstant());
-		assertEquals(REPORT_END_INSTANT, params.getEndInstant());
+		assertEquals(reportStartInstantUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(reportEndInstantUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 
 	@Test
 	public void determineReportPeriod_waterYearOverridesDatesTest() {
 		params.setWaterYear(2018);
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.determineReportPeriod();
-		assertEquals(waterYear2018Begin, params.getStartInstant());
-		assertEquals(waterYear2018End, params.getEndInstant());
+		assertEquals(waterYear2018BeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(waterYear2018EndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void determineReportPeriod_lastmonthsOverridesDatesTest() {
 		params.setLastMonths(3);
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.determineReportPeriod();
-		assertEquals(last3MonthsBegin, params.getStartInstant());
-		assertEquals(last3MonthsEnd, params.getEndInstant());
+		assertEquals(last3MonthsBeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(last3MonthsEndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
@@ -103,41 +105,41 @@ public class RequestParametersTest {
 		params.setLastMonths(3);
 		params.setWaterYear(2018);
 		params.determineReportPeriod();
-		assertEquals(last3MonthsBegin, params.getStartInstant());
-		assertEquals(last3MonthsEnd, params.getEndInstant());
+		assertEquals(last3MonthsBeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(last3MonthsEndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void determineReportPeriod_lastmonthsOverridesAllTest() {
 		params.setLastMonths(3);
 		params.setWaterYear(2018);
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.determineReportPeriod();
-		assertEquals(last3MonthsBegin, params.getStartInstant());
-		assertEquals(last3MonthsEnd, params.getEndInstant());
+		assertEquals(last3MonthsBeginUtc, params.getStartInstant(ZoneOffset.UTC));
+		assertEquals(last3MonthsEndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void getStartInstant_nullTest() {
 		params.setLastMonths(3);
-		assertEquals(last3MonthsBegin, params.getStartInstant());
+		assertEquals(last3MonthsBeginUtc, params.getStartInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void getEndInstant_nullTest() {
 		params.setLastMonths(3);
-		assertEquals(last3MonthsEnd, params.getEndInstant());
+		assertEquals(last3MonthsEndUtc, params.getEndInstant(ZoneOffset.UTC));
 	}
 
 	@Test
 	public void getAsQueryStringAbsoluteBasicTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + REPORT_START_DATE.toString().substring(0, 10) + 
-						"&endDate=" + REPORT_START_DATE.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + reportStartDate.toString().substring(0, 10) + 
+						"&endDate=" + reportStartDate.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, true).compareTo(expected));
 	}
 
@@ -146,8 +148,8 @@ public class RequestParametersTest {
 		params.setWaterYear(2018);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + waterYear2018Begin.toString().substring(0, 10) + 
-						"&endDate=" + waterYear2018End.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + waterYear2018BeginUtc.toString().substring(0, 10) + 
+						"&endDate=" + waterYear2018EndUtc.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, true).compareTo(expected));
 	}
 
@@ -156,19 +158,19 @@ public class RequestParametersTest {
 		params.setLastMonths(3);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + last3MonthsBegin.toString().substring(0, 10) + 
-						"&endDate=" + last3MonthsEnd.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + last3MonthsBeginUtc.toString().substring(0, 10) + 
+						"&endDate=" + last3MonthsEndUtc.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, true).compareTo(expected));
 	}
 
 	@Test
 	public void getAsQueryStringBasicTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + REPORT_START_DATE.toString().substring(0, 10) + 
-						"&endDate=" + REPORT_END_DATE.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + reportStartDate.toString().substring(0, 10) + 
+						"&endDate=" + reportEndDate.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, false).compareTo(expected));
 	}
 
@@ -192,20 +194,20 @@ public class RequestParametersTest {
 
 	@Test
 	public void getAsQueryStringAbsoluteWYOverDatesTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setWaterYear(2018);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + waterYear2018Begin.toString().substring(0, 10) + 
-						"&endDate=" + waterYear2018End.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + waterYear2018BeginUtc.toString().substring(0, 10) + 
+						"&endDate=" + waterYear2018EndUtc.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, true).compareTo(expected));
 	}
 
 	@Test
 	public void getAsQueryStringWYOverDatesTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setWaterYear(2018);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
@@ -215,21 +217,21 @@ public class RequestParametersTest {
 
 	@Test
 	public void getAsQueryStringAbsoluteAllTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setWaterYear(2018);
 		params.setLastMonths(3);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);
 		params.determineReportPeriod();
-		String expected = "startDate=" + last3MonthsBegin.toString().substring(0, 10) + 
-						"&endDate=" + last3MonthsEnd.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
+		String expected = "startDate=" + last3MonthsBeginUtc.toString().substring(0, 10) + 
+						"&endDate=" + last3MonthsEndUtc.toString().substring(0, 10) + "&primaryTimeseriesIdentifier=test-identifier";
 		assertEquals(0, params.getAsQueryString(null, true).compareTo(expected));
 	}
 
 	@Test
 	public void getAsQueryStringAllTest() {
-		params.setEndDate(REPORT_END_DATE);
-		params.setStartDate(REPORT_START_DATE);
+		params.setEndDate(reportEndDate);
+		params.setStartDate(reportStartDate);
 		params.setWaterYear(2018);
 		params.setLastMonths(3);
 		params.setPrimaryTimeseriesIdentifier(primaryIdentifier);

--- a/src/test/java/gov/usgs/aqcu/retrieval/LocationDescriptionServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/retrieval/LocationDescriptionServiceTest.java
@@ -28,8 +28,8 @@ public class LocationDescriptionServiceTest {
 	private AquariusRetrievalService aquariusService;
 
 	private LocationDescriptionService service;
-	LocationDescription locationDescriptionA = new LocationDescription().setIdentifier("a");
-	LocationDescription locationDescriptionB = new LocationDescription().setIdentifier("b");
+	private LocationDescription locationDescriptionA = new LocationDescription().setIdentifier("a");
+	private LocationDescription locationDescriptionB = new LocationDescription().setIdentifier("b");
 
 	@Before
 	@SuppressWarnings("unchecked")

--- a/src/test/java/gov/usgs/aqcu/retrieval/QualifierLookupServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/retrieval/QualifierLookupServiceTest.java
@@ -34,17 +34,17 @@ public class QualifierLookupServiceTest {
 	private Qualifier qualifierB = new Qualifier().setIdentifier("b");
 	private Qualifier qualifierC = new Qualifier().setIdentifier("c");
 	private Qualifier qualifierD = new Qualifier().setIdentifier("d");
-	public static final QualifierMetadata QUALIFIER_METADATA_A = new QualifierMetadata().setIdentifier("a");
-	public static final QualifierMetadata QUALIFIER_METADATA_B = new QualifierMetadata().setIdentifier("b");
-	public static final QualifierMetadata QUALIFIER_METADATA_C = new QualifierMetadata().setIdentifier("c");
-	public static final QualifierMetadata QUALIFIER_METADATA_D = new QualifierMetadata().setIdentifier("d");
+	private QualifierMetadata qualifierMetadataA = new QualifierMetadata().setIdentifier("a");
+	private QualifierMetadata qualifierMetadataB = new QualifierMetadata().setIdentifier("b");
+	private QualifierMetadata qualifierMetadataC = new QualifierMetadata().setIdentifier("c");
+	private QualifierMetadata qualifierMetadataD = new QualifierMetadata().setIdentifier("d");
 
 	@Before
 	@SuppressWarnings("unchecked")
 	public void setup() throws Exception {
 		service = new QualifierLookupService(aquariusService);
 		given(aquariusService.executePublishApiRequest(any(IReturn.class))).willReturn(new QualifierListServiceResponse()
-				.setQualifiers(new ArrayList<QualifierMetadata>(Arrays.asList(QUALIFIER_METADATA_A, QUALIFIER_METADATA_B, QUALIFIER_METADATA_C, QUALIFIER_METADATA_D))));
+				.setQualifiers(new ArrayList<QualifierMetadata>(Arrays.asList(qualifierMetadataA, qualifierMetadataB, qualifierMetadataC, qualifierMetadataD))));
 	}
 
 	@Test
@@ -56,27 +56,27 @@ public class QualifierLookupServiceTest {
 
 	@Test
 	public void filterListTest() {
-		Map<String, QualifierMetadata> actual = service.filterList(Arrays.asList("a", "c", "d"), Arrays.asList(QUALIFIER_METADATA_A, QUALIFIER_METADATA_B, QUALIFIER_METADATA_C, QUALIFIER_METADATA_D));
+		Map<String, QualifierMetadata> actual = service.filterList(Arrays.asList("a", "c", "d"), Arrays.asList(qualifierMetadataA, qualifierMetadataB, qualifierMetadataC, qualifierMetadataD));
 		assertEquals(3, actual.size());
-		assertThat(actual, IsMapContaining.hasEntry("a", QUALIFIER_METADATA_A));
-		assertThat(actual, IsMapContaining.hasEntry("c", QUALIFIER_METADATA_C));
-		assertThat(actual, IsMapContaining.hasEntry("d", QUALIFIER_METADATA_D));
+		assertThat(actual, IsMapContaining.hasEntry("a", qualifierMetadataA));
+		assertThat(actual, IsMapContaining.hasEntry("c", qualifierMetadataC));
+		assertThat(actual, IsMapContaining.hasEntry("d", qualifierMetadataD));
 		}
 
 	@Test
 	public void getTest() throws Exception {
 		List<QualifierMetadata> actual = service.get();
 		assertEquals(4, actual.size());
-		assertThat(actual, containsInAnyOrder(QUALIFIER_METADATA_A, QUALIFIER_METADATA_B, QUALIFIER_METADATA_C, QUALIFIER_METADATA_D));
+		assertThat(actual, containsInAnyOrder(qualifierMetadataA, qualifierMetadataB, qualifierMetadataC, qualifierMetadataD));
 	}
 
 	@Test
 	public void getByQualifierList_happyPathTest() {
 		Map<String, QualifierMetadata> actual = service.getByQualifierList(Arrays.asList(qualifierA, qualifierC, qualifierD));
 		assertEquals(3, actual.size());
-		assertThat(actual, IsMapContaining.hasEntry("a", QUALIFIER_METADATA_A));
-		assertThat(actual, IsMapContaining.hasEntry("c", QUALIFIER_METADATA_C));
-		assertThat(actual, IsMapContaining.hasEntry("d", QUALIFIER_METADATA_D));
+		assertThat(actual, IsMapContaining.hasEntry("a", qualifierMetadataA));
+		assertThat(actual, IsMapContaining.hasEntry("c", qualifierMetadataC));
+		assertThat(actual, IsMapContaining.hasEntry("d", qualifierMetadataD));
 	}
 
 }


### PR DESCRIPTION
Having the report period as a pair of LocalDate and adding time component along with ZoneOffset at request time appears to make the daily and instantaneous timeseries calls behave much better. 