### PR TITLE
Revert sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <additionalparam>-Xdoclint:none</additionalparam>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <aquarius.sdk.version>18.7.1</aquarius.sdk.version>
+        <aquarius.sdk.version>18.6.2</aquarius.sdk.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Operations is rolling back the AQ18.3 release because of some big bugs, setting this up to change back to the old version when that is finished.