### PR TITLE
Added configurable timeouts to Aquarius retrievals. Updated the…

### DIFF
--- a/src/main/java/gov/usgs/aqcu/retrieval/AquariusRetrievalService.java
+++ b/src/main/java/gov/usgs/aqcu/retrieval/AquariusRetrievalService.java
@@ -6,8 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
-import java.net.SocketTimeoutException;
-
 import com.aquaticinformatics.aquarius.sdk.timeseries.AquariusClient;
 
 import gov.usgs.aqcu.exception.AquariusProcessingException;

--- a/src/main/java/gov/usgs/aqcu/retrieval/AquariusRetrievalService.java
+++ b/src/main/java/gov/usgs/aqcu/retrieval/AquariusRetrievalService.java
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
+import java.net.SocketTimeoutException;
+
 import com.aquaticinformatics.aquarius.sdk.timeseries.AquariusClient;
 
 import gov.usgs.aqcu.exception.AquariusProcessingException;
@@ -30,7 +32,14 @@ public class AquariusRetrievalService {
 	@Value("${aquarius.service.retries.unauthorized}")
 	protected int aquariusUnauthorizedRetryCount;
 
+	@Value("${aquarius.service.timeout}")
+	protected int aquariusTimeoutMs;
+
 	protected <TResponse> TResponse executePublishApiRequest(IReturn<TResponse> request) throws AquariusRetrievalException {
+		return executePublishApiRequest(request, null);
+	}
+
+	protected <TResponse> TResponse executePublishApiRequest(IReturn<TResponse> request, Integer timeoutMsOverride) throws AquariusRetrievalException {
 		String errorMessage = "";
 		int unauthorizedRetryCounter = 0;
 		boolean doRetry;
@@ -38,9 +47,17 @@ public class AquariusRetrievalService {
 		do {
 			doRetry = false;
 			try {
-				//Despite this being AutoCloseable we CANNOT close it or it will delete the session in AQ for our service account
-				//and cause any other in-flight requests to fail.
+				// Despite this being AutoCloseable we CANNOT close it or it will delete the session in AQ for our service account
+				// and cause any other in-flight requests to fail.
 				AquariusClient client = AquariusClient.createConnectedClient(aquariusUrl.replace("/AQUARIUS/", ""), aquariusUser, aquariusPassword);
+				
+				// Allow specifying a timeout MS per-request
+				if(timeoutMsOverride != null) {
+					client.Publish.setTimeout(timeoutMsOverride);
+				} else {
+					client.Publish.setTimeout(aquariusTimeoutMs);
+				}
+				
 				return client.Publish.get(request);
 			} catch (WebServiceException e) {
 				if((isAuthError(e) || isInvalidTokenError(e)) && unauthorizedRetryCounter < aquariusUnauthorizedRetryCount) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ aquarius:
   service:
     retries:
       unauthorized: ${aquariusUnauthorizedRetires:3}
+    timeout: 30000
 
 #eureka:
 #  client:

--- a/src/test/java/gov/usgs/aqcu/retrieval/TimeSeriesDataServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/retrieval/TimeSeriesDataServiceTest.java
@@ -97,32 +97,15 @@ public class TimeSeriesDataServiceTest {
 			.setTimestamp(new StatisticalDateTimeOffset().setDateTimeOffset(Instant.parse("2017-01-02T00:00:00Z")))
 			.setValue(new DoubleWithDisplay().setDisplay("1").setNumeric(2.0))
 	));
-	
-	public TimeSeriesDataServiceResponse TS_DATA_RESPONSE;
 
+	private TimeSeriesDataServiceResponse TS_DATA_RESPONSE;
+	
 	@Before
 	@SuppressWarnings("unchecked")
 	public void setup() throws Exception {
 		service = new TimeSeriesDataService(aquariusService);
 		parameters = new ReportRequestParameters();
-		TS_DATA_RESPONSE = new TimeSeriesDataServiceResponse()
-			.setApprovals(approvals)
-			.setGapTolerances(gapTolerances)
-			.setGrades(grades)
-			.setInterpolationTypes(interps)
-			.setLabel("label")
-			.setLocationIdentifier("loc-id")
-			.setMethods(methods)
-			.setNotes(notes)
-			.setNumPoints(new Long("1"))
-			.setParameter("param")
-			.setPoints(points)
-			.setQualifiers(new ArrayList<Qualifier>(Arrays.asList(qualifierA, qualifierB, qualifierC)))
-			.setTimeRange(new StatisticalTimeRange()
-				.setStartTime(new StatisticalDateTimeOffset().setDateTimeOffset(Instant.parse("2017-01-01T00:00:00Z")))
-				.setEndTime(new StatisticalDateTimeOffset().setDateTimeOffset(Instant.parse("2017-03-01T00:00:00Z"))))
-			.setUniqueId("uuid")
-			.setUnit("unit");
+		TS_DATA_RESPONSE = buildData();
 		given(aquariusService.executePublishApiRequest(any(IReturn.class))).willReturn(TS_DATA_RESPONSE);
 	}
 
@@ -170,5 +153,26 @@ public class TimeSeriesDataServiceTest {
 		assertEquals(result.getTimeRange(), TS_DATA_RESPONSE.getTimeRange());
 		assertEquals(result.getQualifiers(), TS_DATA_RESPONSE.getQualifiers());
 		assertEquals(result.getPoints().size(), 1);
+	}
+
+	public static TimeSeriesDataServiceResponse buildData() {
+		return new TimeSeriesDataServiceResponse()
+			.setApprovals(approvals)
+			.setGapTolerances(gapTolerances)
+			.setGrades(grades)
+			.setInterpolationTypes(interps)
+			.setLabel("label")
+			.setLocationIdentifier("loc-id")
+			.setMethods(methods)
+			.setNotes(notes)
+			.setNumPoints(new Long("1"))
+			.setParameter("param")
+			.setPoints(points)
+			.setQualifiers(new ArrayList<Qualifier>(Arrays.asList(qualifierA, qualifierB, qualifierC)))
+			.setTimeRange(new StatisticalTimeRange()
+				.setStartTime(new StatisticalDateTimeOffset().setDateTimeOffset(Instant.parse("2017-01-01T00:00:00Z")))
+				.setEndTime(new StatisticalDateTimeOffset().setDateTimeOffset(Instant.parse("2017-03-01T00:00:00Z"))))
+			.setUniqueId("uuid")
+			.setUnit("unit");
 	}
 }


### PR DESCRIPTION
…TimeSeriesDataTest to allow accessing the TimeSeriesDataServiceResponse in other tests (fixes an issue with the TSS report).