### PR TITLE
Added Condition checks for instantiating NWIS-RA and JavaToR clients …

### DIFF
--- a/src/main/java/gov/usgs/aqcu/client/JavaToRClient.java
+++ b/src/main/java/gov/usgs/aqcu/client/JavaToRClient.java
@@ -1,5 +1,6 @@
 package gov.usgs.aqcu.client;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -7,7 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name="javaToR", url="${javaToR.service.endpoint}")
+@FeignClient(name="javaToR", url="${javaToR.service.endpoint:}")
+@ConditionalOnProperty(name="javaToR.service.endpoint")
 public interface JavaToRClient {
 
 	@RequestMapping(method=RequestMethod.POST, value="/report/{reportType}")

--- a/src/main/java/gov/usgs/aqcu/client/NwisRaClient.java
+++ b/src/main/java/gov/usgs/aqcu/client/NwisRaClient.java
@@ -1,12 +1,14 @@
 package gov.usgs.aqcu.client;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name="nwisRa", url="${nwis-ra.service.endpoint:https://placeholder.gov}")
+@FeignClient(name="nwisRa", url="${nwis-ra.service.endpoint:}")
+@ConditionalOnProperty(name="nwis-ra.service.endpoint")
 public interface NwisRaClient {
 
 	@RequestMapping(method=RequestMethod.GET, value="/data/view/parameters/json", consumes="application/json")

--- a/src/main/java/gov/usgs/aqcu/retrieval/NwisRaService.java
+++ b/src/main/java/gov/usgs/aqcu/retrieval/NwisRaService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 
@@ -23,6 +24,7 @@ import gov.usgs.aqcu.model.nwis.WaterQualitySampleRecords;
 import gov.usgs.aqcu.parameter.DateRangeRequestParameters;
 
 @Repository
+@ConditionalOnBean(NwisRaClient.class)
 public class NwisRaService {
 	private static final Logger LOG = LoggerFactory.getLogger(NwisRaService.class);
 


### PR DESCRIPTION
…and the NWISRA Service. Fixes issues with aqcu-lookups.

- `ConditionalOnProperty` - This class is only instantiated as a Bean by SpringBoot if the provided configuration property is set. Effectively this means that services which don't define the NwisRa or JavaToR configuration details won't have these clients instantiated at all. Previously the clients were instantiated with a dummy URL.

- `ConditionalOnBean` - This class is only instantiated as bean by SpringBoot if there exists an instantiated Bean of the provided class. Effectively this means that the NwisRaService will only be instantiated if the NwisRaClient is instantiated, transitively implying that the NwisRaService will only be instantiated if the application defines the `nwis-ra.service.url` property.

These additions were necessary because aqcu-lookups does not use NwisRa or JavaToR. When I updated aqcu-lookups to the latest framework version (which pulled the NwisRaService and NwisRaClient into it) aqcu-lookups could not start because it had FeignClients disabled (since it doesn't need to use them), resulting in no NwisRaClient being instantiated, which led to an error when NwisRaService was instantiated. Rather than forcing aqcu-lookups to enable FeignClients which it doesn't use I decided to opt for conditionally disabling these optional parts of the aqcu-framework instead. With these changes aqcu-lookups never tries to instantiate the NwisRaService Bean because the `ConditionalOnBean(NwisRaClient.class)` check fails.